### PR TITLE
Fix definition of all-day event.

### DIFF
--- a/haunts/calendars.py
+++ b/haunts/calendars.py
@@ -79,7 +79,7 @@ def create_event(config_dir, calendar, date, summary, details, length, from_time
             "date": start.isoformat()[:10],
         }
         endParams = {
-            "date": end.isoformat()[:10],
+            "date": (end + datetime.timedelta(days=1)).isoformat()[:10],
         }
 
     event = {


### PR DESCRIPTION
Hopefully it doesn't break on the DST changes (1 day is different from 24 hours twice a year).